### PR TITLE
Sort: check for identical words

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,10 @@ function buildAlphabet(): string {
 }
 
 const compare = (a: string, b: string, index: number, alphabet: string) : number => {
+  if (a === b) {
+    return 0;
+  }
+
   const indexA: number = alphabet.indexOf(a[index]?.toLowerCase());
   const indexB: number = alphabet.indexOf(b[index]?.toLowerCase());
 

--- a/tests/old-norse-alphabet-sort.test.ts
+++ b/tests/old-norse-alphabet-sort.test.ts
@@ -22,4 +22,12 @@ describe('Old Norse Alphabet sort', () => {
 
     expect(result).toEqual(expected);
   });
+
+  test('Sorts cases with identical words (issue #48)', () => {
+    const words = ['aðili', 'maðka', 'þakkan', 'maðka'];
+    const expected = ['aðili', 'maðka', 'maðka', 'þakkan'];
+    const result = [...words].sort((a, b) => oldNorseSort(a, b));
+
+    expect(result).toEqual(expected);
+  });
 });


### PR DESCRIPTION
Return “0” if words are identical. Fixes #48